### PR TITLE
Add format flags in calls to error.

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -598,7 +598,7 @@ to variable \texttt{v}.
        [`(read)
         (let ([r (read)])
           (cond [(fixnum? r) r]
-                 [else (error 'interp-R0 "input not an integer" r)]))]
+                 [else (error 'interp-R0 "input not an integer: ~a" r)]))]
        [`(- ,(app interp-R0 v))
         (fx- 0 v)]
        [`(+ ,(app interp-R0 v1) ,(app interp-R0 v2))
@@ -886,7 +886,7 @@ to the variable, then evaluates the body of the \key{let}.
          [`(read)
           (define r (read))
           (cond [(fixnum? r) r]
-                [else (error 'interp-R1 "expected an integer" r)])]
+                [else (error 'interp-R1 "expected an integer: ~a" r)])]
          [`(- ,(app recur v))
           (fx- 0 v)]
          [`(+ ,(app recur v1) ,(app recur v2))
@@ -3097,7 +3097,7 @@ association list.
          [`(not ,(app (typecheck-R2 env) T))
           (match T
             ['Boolean 'Boolean]
-            [else (error 'typecheck-R2 "'not' expects a Boolean" e)])]
+            [else (error 'typecheck-R2 "'not' expects a Boolean: ~a" e)])]
          ...
          [`(program ,body)
           (define ty ((typecheck-R2 '()) body))
@@ -4012,7 +4012,7 @@ flattening).
           (let ([t (list-ref ts i)])
             (values `(has-type (vector-ref ,e (has-type ,i Integer)) ,t) 
                     t))]
-         [else (error "expected a vector in vector-ref, not" t)])]
+         [else (error "expected a vector in vector-ref, not ~a" t)])]
       [`(vector-set! ,(app (type-check env) e-vec^ t-vec) ,i 
                      ,(app (type-check env) e-arg^ t-arg)) 
        (match t-vec
@@ -5032,7 +5032,7 @@ Figure~\ref{fig:interp-R4}.
                [`(lambda (,xs ...) ,body)
                  (define new-env (append (map cons xs arg-vals) env))
  		 ((interp-R4 new-env) body)]
-               [else (error "interp-R4, expected function, not" fun-val)]))]
+               [else (error "interp-R4, expected function, not ~a" fun-val)]))]
          [else (error 'interp-R4 "unrecognized expression")]
          )))
 \end{lstlisting}
@@ -5687,7 +5687,7 @@ top-level environment.
            [`(lambda (,xs ...) ,body ,lam-env)
             (define new-env (append (map cons xs arg-vals) lam-env))
             ((interp-R5 new-env) body)]
-           [else (error "interp-R5, expected function, not" fun-val)])]
+           [else (error "interp-R5, expected function, not ~a" fun-val)])]
        )))
 \end{lstlisting}
 \caption{Interpreter for $R_5$.}
@@ -5713,7 +5713,7 @@ require the body's type to match the declared return type.
        (cond [(equal? rT bodyT)
               `(,@Ts -> ,rT)]
              [else
-              (error "mismatch in return type" bodyT rT)])]
+              (error "mismatch in return type ~a ~a" bodyT rT)])]
       ...
       )))
 \end{lstlisting}
@@ -6029,7 +6029,7 @@ The type checker for $R_6$ is given in Figure~\ref{fig:typecheck-R6}.
          [(equal? e-ty 'Any)
           (values `(,pred ,new-e) 'Boolean)]
          [else
-          (error "predicate expected arg of type Any, not" e-ty)])]
+          (error "predicate expected arg of type Any, not ~a" e-ty)])]
        [`(vector-ref ,(app recur e t) ,i)
         (match t
           [`(Vector ,ts ...) ...]
@@ -6037,7 +6037,7 @@ The type checker for $R_6$ is given in Figure~\ref{fig:typecheck-R6}.
            (unless (exact-nonnegative-integer? i)
              (error 'type-check "invalid index ~a" i))
            (values `(vector-ref ,e ,i) t)]
-          [else (error "expected a vector in vector-ref, not" t)])]
+          [else (error "expected a vector in vector-ref, not ~a" t)])]
        [`(vector-set! ,(app recur e-vec^ t-vec) ,i
                        ,(app recur e-arg^ t-arg))
         (match t-vec
@@ -6093,9 +6093,9 @@ for $R_6$.
             (cond [(equal? t1 t2)
                    v1]
                   [else
-                   (error "in project, type mismatch" t1 t2)])]
+                   (error "in project, type mismatch ~a ~a" t1 t2)])]
            [else
-            (error "in project, expected tagged value" v)])]
+            (error "in project, expected tagged value ~a" v)])]
        ...)))
 \end{lstlisting}
 \caption{Interpreter for $R_6$.}
@@ -6190,7 +6190,7 @@ Figure~\ref{fig:interp-R7}.
          [`(inject (lambda (,xs ...) ,body ,lam-env) ,ty)
           (define new-env (append (map cons xs vs) lam-env))
           ((interp-r7 new-env) body)]
-         [else (error "interp-r7, expected function, not" f-val)])])))
+         [else (error "interp-r7, expected function, not ~a" f-val)])])))
 \end{lstlisting}
 \caption{Interpreter for the $R_7$ language.}
 \label{fig:interp-R7}


### PR DESCRIPTION
In some of the calls to `error` values are being passed but the error
message does not contain format flags. I have added the "~a" flag where necessary.