### PR TITLE
Distinguish between flatten and flatten-exp

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1684,8 +1684,10 @@ $\Rightarrow$
 \end{minipage}
 \end{tabular}
 
-We recommend implementing \key{flatten} as a structurally recursive
-function that returns three things, 1) the newly flattened expression,
+We recommend implementing a helper function,
+\key{flatten-exp}, as a structurally recursive
+function that takes an expression in $R_1$ and
+returns three things: 1) the newly flattened expression,
 2) a list of assignment statements, one for each of the new variables
 introduced during the flattening the expression, and 3) a list of all
 the variables including both let-bound variables and the generated
@@ -1701,8 +1703,27 @@ Also, the \key{map3} function
 to each element of a list, in the case where the function returns
 three values. The result of \key{map3} is three lists.
 
+\begin{tabular}{lll}
+\begin{minipage}{0.4\textwidth}
+\begin{lstlisting}
+(flatten-exp `(+ 52 (- 10)))
+\end{lstlisting}
+\end{minipage}
+&
+$\Rightarrow$
+&
+\begin{minipage}{0.4\textwidth}
+\begin{lstlisting}
+  (values 'tmp.2
+  '((assign tmp.1 (- 10))
+    (assign tmp.2 (+ 52 tmp.1)))
+  '(tmp.1 tmp.2))
+\end{lstlisting}
+\end{minipage}
+\end{tabular}
+
 The clause of \key{flatten} for the \key{program} node needs to
-recursively flatten the body of the program and the newly flattened
+apply this helper function to the body of the program and the newly flattened
 expression should be placed in a \key{return} statement. Remember that
 the variable list in the \key{program} node should contain no duplicates.
 %% The


### PR DESCRIPTION
Came up in the lecture today.

The book seems to say, first, that `flatten` should returns the `arg`, assignments, and variables, then later it implies that it should return a C0 program. I don't think it's clear that the intended `flatten` function here actually returns different types based on what it matches on.

I changed the wording to describe a helper function, and showed its output on the running example program.