### PR TITLE
removed the `not` case in interp-exp for R2

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -543,7 +543,7 @@ The pattern is not the same thing as a quasiquote expression used to
 \emph{construct} ASTs, however, the similarity is intentional: constructing and
 deconstructing ASTs uses similar syntax.
 %
-While the pattern uses a restricted syntax, 
+While the pattern uses a restricted syntax,
 the body of the match clause may contain any Racket code whatsoever.
 
 
@@ -574,7 +574,7 @@ S-expression to see if it is a machine-representable integer.
 \vrule
 \begin{minipage}{0.25\textwidth}
   \begin{lstlisting}
-    
+
 
 
 
@@ -618,11 +618,11 @@ $R_0$ program.
     [`(- ,e) (exp? e)]
     [`(+ ,e1 ,e2)
       (and (exp? e1) (exp? e2))]
-    [else #f]))  
+    [else #f]))
 
 (define (R0? sexp)
   (match sexp
-    [`(program ,e) (exp? e)]    
+    [`(program ,e) (exp? e)]
     [else #f]))
 
 (R0? `(program (+ (read) (- 8))))
@@ -638,7 +638,7 @@ $R_0$ program.
 
 
 
-  
+
 
 
 
@@ -1035,7 +1035,7 @@ to the variable, then evaluates the body of the \key{let}.
           (fx- 0 v)]
          [`(+ ,(app (interp-exp env) v1) ,(app (interp-exp env) v2))
            (fx+ v1 v2)])))
-           
+
    (define (interp-R1 env)
      (lambda (p)
        (match p
@@ -1237,7 +1237,7 @@ main:
 	addq	-8(%rbp), %rax
 	movq	%rax, %rdi
 	callq	print_int
-        
+
 	addq	$16, %rsp
 	movq    $0, %rax
 	popq	%rbp
@@ -1319,7 +1319,7 @@ next. )
              (\key{subq} \; \Arg\; \Arg) \mid
              (\key{movq} \; \Arg\; \Arg) \mid
              (\key{retq})\\
-      &\mid& (\key{negq} \; \Arg) \mid 
+      &\mid& (\key{negq} \; \Arg) \mid
              (\key{callq} \; \mathit{label}) \mid
              (\key{pushq}\;\Arg) \mid
              (\key{popq}\;\Arg) \\
@@ -3235,7 +3235,6 @@ the order of evaluation of its arguments.
           (match cnd
             [#t (recur thn)]
             [#f (recur els)])]
-         [`(not ,(app recur v)) (match v [#t #f] [#f #t])]
          [`(and ,(app recur v1) ,e2)
           (match v1
             [#t (match (recur e2) [#t #t] [#f #f])]
@@ -5005,7 +5004,7 @@ needs to be followed. Thus, we zero-out all locations on the root
 stack in the prelude of \code{main}. In
 Figure~\ref{fig:print-x86-output-gc}, the instruction
 %
-\lstinline{movq $0, (%r15)} 
+\lstinline{movq $0, (%r15)}
 %
 accomplishes this task. The garbage collector tests each root to see
 if it is null prior to dereferencing it.


### PR DESCRIPTION
the `not` case in the interpreter seems redundant, since we already handle `not` in `interp-op`
