### PR TITLE
Fix figure 2.5

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1244,8 +1244,8 @@ $-16\key{(\%rbp)}$, etc.
 start:
 	movq	$10, -8(%rbp)
 	negq	-8(%rbp)
-	movq	-8(%rbp), %rax
-	addq	$52, %rax
+	movq	$52, %rax
+	addq	-8(%rbp), %rax
 	jmp conclusion
 
 	.globl main


### PR DESCRIPTION
On page 23, the book mentions moving 52 to %rax and adding
contents of var 1 to %rax, but the figure does the opposite, i.e,
move contents of var 1 to %rax, and adds 52 to rax.