### PR TITLE
Fix typos in chapter 2

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1316,7 +1316,7 @@ x86 programs, so we define an abstract syntax for x86 in
 Figure~\ref{fig:x86-ast-a}. We refer to this language as $x86_0$ with
 a subscript $0$ because later we introduce extended versions of this
 assembly language. The main difference compared to the concrete syntax
-of x86 (Figure~\ref{fig:x86-a}) is that it does nto allow labelled
+of x86 (Figure~\ref{fig:x86-a}) is that it does not allow labelled
 instructions to appear anywhere, but instead organizes instructions
 into groups called \emph{blocks} and a label is associated with every
 block, which is why the \key{program} form includes an association
@@ -1533,7 +1533,7 @@ $C_0$.  The syntax for $C_0$ is defined in Figure~\ref{fig:c0-syntax}.
 The $C_0$ language supports the same operators as $R_1$ but the
 arguments of operators are now restricted to just variables and
 integers, thanks to the \key{remove-complex-opera*} pass.  In the
-literature this style of intermediate language is called
+literature, this style of intermediate language is called
 administrative normal form, or ANF for
 short~\citep{Danvy:1991fk,Flanagan:1993cg}.  Instead of \key{let}
 expressions, $C_0$ has assignment statements which can be executed in
@@ -1541,7 +1541,7 @@ sequence using the \key{seq} construct. A sequence of statements
 always ends with \key{return}, a guarantee that is baked into the
 grammar rules for the \itm{tail} non-terminal. The naming of this
 non-terminal comes from the term \emph{tail position}, which refers to
-an expression that is the last one to execute within a function. (A
+an expression that is the last one to execute within a function. (An
 expression in tail position may contain subexpressions, and those may
 or may not be in tail position depending on the kind of expression.)
 
@@ -1552,7 +1552,7 @@ having to change the syntax of the program construct in
 Chapter~\ref{ch:bool-types}.  For now there will be just one label,
 \key{start}, and the whole program will be it's tail.
 %
-The $\itm{info}$ field of the program construt, after the
+The $\itm{info}$ field of the program construct, after the
 \key{uncover-locals} pass, will contain a mapping from the symbol
 \key{locals} to a list of variables, that is, a list of all the
 variables used in the program. At the start of the program, these
@@ -1765,7 +1765,7 @@ $\Rightarrow$
 We recommend implementing this pass with two mutually recursive
 functions, \code{rco-arg} and \code{rco-exp}. The idea is to apply
 \code{rco-arg} to subexpressions that need to become simple and to
-apply \code{rco-exp} to subexpressions can stay complex.  
+apply \code{rco-exp} to subexpressions that can stay complex.
 Both functions take an expression in $R_1$ as input.
 The \code{rco-exp} function returns an expression.
 The \code{rco-arg} function returns two things:


### PR DESCRIPTION
* Add comma for readability:

  in the literature this style... -> in the literature, this style...

* Fix typos

  A expression -> An expression

  construt -> construct

  apply rco-exp to subexp can stay... ->
  apply rco-exp to subexp that can stay...

  does nto -> does not