### PR TITLE
fix typo: R0 has no - with two args

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -607,8 +607,7 @@ Appendix~\ref{appendix:utilities} for more details.
 \[
 \begin{array}{rcl}
 \begin{array}{rcl}
-  \Exp &::=& \Int \mid (\key{read}) \mid (\key{-}\;\Exp) \mid (\key{+} \; \Exp\;\Exp)
-        \mid (\key{-}\;\Exp\;\Exp) \\
+  \Exp &::=& \Int \mid (\key{read}) \mid (\key{-}\;\Exp) \mid (\key{+} \; \Exp\;\Exp)\\
   R_0 &::=& \Exp
 \end{array}
 \end{array}


### PR DESCRIPTION
The concrete syntax of R0 (Figure 1.1) does not agree with the abstract syntax of R0 (Figure 1.2)