### PR TITLE
remove extra ) from Figure 1.3

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -857,7 +857,7 @@ $R_0$ expressions.
      (define v1 (interp-exp e1))
      (define v2 (interp-exp e2))
      (fx+ v1 v2)]
-    )))
+    ))
 
 (define (interp-R0 p)
   (match p


### PR DESCRIPTION
There is an extra ")" in Figure 1.3: Interpreter for the R0
