### PR TITLE
Fix typo in interp-R0 error

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -144,7 +144,7 @@ moredelim=[is][\color{red}]{~}{~}
   Ryan Scott \\
   Cameron Swords \\
   Michael M. Vitousek \\
-  Michael Vollmer 
+  Michael Vollmer
    }
 
 \begin{document}
@@ -707,7 +707,7 @@ body of the first clause that matches is executed. The output of
 
 
 
-    
+
    #t
    #f
    #t
@@ -851,7 +851,7 @@ $R_0$ expressions.
     [(Prim 'read '())
      (define r (read))
      (cond [(fixnum? r) r]
-           [else (error 'interp-R1 "expected an integer" r)])]
+           [else (error 'interp-R0 "expected an integer" r)])]
     [(Prim '- (list e))
      (define v (interp-exp e))
      (fx- 0 v)]
@@ -1509,17 +1509,17 @@ the $\itm{info}$ field should just contain an empty list.
 \begin{figure}[tp]
 \fbox{
 \begin{minipage}{0.96\textwidth}
-\small    
+\small
 \[
 \begin{array}{lcl}
 \Reg &::=& \allregisters{} \\
 \Arg &::=&  \IMM{\Int} \mid \REG{\code{'}\Reg}
    \mid \DEREF{\Reg}{\Int} \\
-\Instr &::=& \BININSTR{\code{'addq}}{\Arg}{\Arg} 
+\Instr &::=& \BININSTR{\code{'addq}}{\Arg}{\Arg}
        \mid \BININSTR{\code{'subq}}{\Arg}{\Arg} \\
        &\mid& \BININSTR{\code{'movq}}{\Arg}{\Arg}
        \mid \UNIINSTR{\code{'negq}}{\Arg}\\
-       &\mid& \CALLQ{\itm{label}} \mid \RETQ{} 
+       &\mid& \CALLQ{\itm{label}} \mid \RETQ{}
        \mid \PUSHQ{\Arg} \mid \POPQ{\Arg} \mid \JMP{\itm{label}} \\
 \Block &::= & \BLOCK{\itm{info}}{\Instr^{+}} \\
 x86_0 &::= & \PROGRAM{\itm{info}}{\CFG{\key{(}\itm{label} \,\key{.}\, \Block \key{)}^{+}}}
@@ -1593,7 +1593,7 @@ non-terminal in the grammar of the input language of the pass.
   \key{opera*}) is an \emph{atomic} expression (a variable or
   integer), we introduce temporary variables to hold the results
   of subexpressions.
-  
+
 \item[Pass \key{explicate-control}] To make the execution order of the
   program explicit, we convert from the abstract syntax tree
   representation into a \emph{control-flow graph} in which each node
@@ -2098,7 +2098,7 @@ output of \code{explicate-control} makes this ordering explicit.\\
 \begin{tabular}{lll}
 \begin{minipage}{0.4\textwidth}
 \begin{lstlisting}
-(let ([y (let ([x.1 20]) 
+(let ([y (let ([x.1 20])
            (let ([x.2 22])
              (+ x.1 x.2)))])
  y)
@@ -2276,7 +2276,7 @@ this example, we assign variable \code{a} to stack location
   \begin{minipage}{0.4\textwidth}
 \begin{lstlisting}[basicstyle=\ttfamily\footnotesize]
 locals: a b
-start: 
+start:
     movq $42, a
     movq a, b
     movq b, %rax
@@ -2397,7 +2397,7 @@ If you want your program to run on Mac OS X, your code needs to
 determine whether or not it is running on a Mac, and prefix
 underscores to labels like \key{main}.  You can determine the platform
 with the Racket call \code{(system-type 'os)}, which returns
-\code{'macosx}, \code{'unix}, or \code{'windows}.  
+\code{'macosx}, \code{'unix}, or \code{'windows}.
 %% In addition to
 %% placing underscores on \key{main}, you need to put them in front of
 %% \key{callq} labels (so \code{callq print\_int} becomes \code{callq
@@ -2424,7 +2424,7 @@ introduced in Section~\ref{sec:partial-evaluation}.
 
 \begin{exercise}\label{ex:pe-R1}
 \normalfont
-  
+
 Adapt the partial evaluator from Section~\ref{sec:partial-evaluation}
 (Figure~\ref{fig:pe-arith}) so that it applies to $R_1$ programs
 instead of $R_0$ programs. Recall that $R_1$ adds \key{let} binding
@@ -2795,7 +2795,7 @@ addq b, c
 \vrule\hspace{10pt}
 \begin{minipage}{0.45\textwidth}
 \begin{align*}
-L_{\mathsf{before}}(1)=  \emptyset, 
+L_{\mathsf{before}}(1)=  \emptyset,
 L_{\mathsf{after}}(1)=  \{a\}\\
 L_{\mathsf{before}}(2)=  \{a\},
 L_{\mathsf{after}}(2)=  \{a\}\\
@@ -2817,27 +2817,27 @@ sets shown between each instruction to make the figure easy to read.
 \hspace{20pt}
 \begin{minipage}{0.45\textwidth}
 \begin{lstlisting}
-                       |$\{\}$|    
+                       |$\{\}$|
     movq $1, v
-                       |$\{v\}$|    
+                       |$\{v\}$|
     movq $42, w
-                       |$\{v,w\}$|    
+                       |$\{v,w\}$|
     movq v, x
-                       |$\{w,x\}$|    
+                       |$\{w,x\}$|
     addq $7, x
-                       |$\{w,x\}$|    
+                       |$\{w,x\}$|
     movq x, y
-                       |$\{w,x,y\}$|    
+                       |$\{w,x,y\}$|
     movq x, z
-                       |$\{w,y,z\}$|    
+                       |$\{w,y,z\}$|
     addq w, z
-                       |$\{y,z\}$|    
+                       |$\{y,z\}$|
     movq y, t
-                       |$\{t,z\}$|    
+                       |$\{t,z\}$|
     negq t
-                       |$\{t,z\}$|    
+                       |$\{t,z\}$|
     movq z, %rax
-                       |$\{t\}$|    
+                       |$\{t\}$|
     addq t, %rax
                        |$\{\}$|
     jmp conclusion
@@ -3281,7 +3281,7 @@ registers and stack locations.
      w \mapsto \key{\%rcx},  \,
      x \mapsto \key{-8(\%rbp)}, \\
      y \mapsto \key{-16(\%rbp)},  \,
-     z\mapsto \key{-8(\%rbp)}, 
+     z\mapsto \key{-8(\%rbp)},
      t\mapsto \key{\%rcx} \}
 \end{gather*}
 Applying this assignment to our running example, on the left, yields
@@ -3373,7 +3373,7 @@ shown in Figure~\ref{fig:reg-alloc-passes}.
   \code{uncover-live}, \code{build-interference}, and
   \code{allocate-registers} replace the \code{assign-homes} pass of
   Section~\ref{sec:assign-r1}.
-  
+
   We recommend that you create a helper function named
   \code{color-graph} that takes an interference graph and a list of
   all the variables in the program. This function should return a
@@ -3391,7 +3391,7 @@ shown in Figure~\ref{fig:reg-alloc-passes}.
   code from the \code{assign-homes} pass from
   Section~\ref{sec:assign-r1} to replace the variables with their
   assigned location.
-  
+
   Test your updated compiler by creating new example programs that
   exercise all of the register allocation algorithm, such as forcing
   variables to be spilled to the stack.
@@ -3594,7 +3594,7 @@ So we have the following assignment of variables to registers.
      w \mapsto \key{\%rdx},  \,
      x \mapsto \key{\%rbx}, \\
      y \mapsto \key{\%rbx},  \,
-     z\mapsto \key{\%rcx}, 
+     z\mapsto \key{\%rcx},
      t\mapsto \key{\%rbx} \}
 \end{gather*}
 
@@ -3693,7 +3693,7 @@ spilled variables), then we pop the old values of \code{rbx} and
 \code{rbp} (callee-saved registers), and finish with \code{retq} to
 return control to the operating system.
 
-  
+
 \begin{figure}[tbp]
   % s0_28.rkt
   % (use-minimal-set-of-registers! #t)
@@ -3723,7 +3723,7 @@ main:
 	pushq	%rbx
 	subq	$8, %rsp
 	jmp start
-        
+
 conclusion:
 	addq	$8, %rsp
 	popq	%rbx
@@ -3811,7 +3811,7 @@ operators to include
 \begin{minipage}{0.96\textwidth}
 \[
 \begin{array}{lcl}
-  \itm{bool} &::=& \key{\#t} \mid \key{\#f} \\  
+  \itm{bool} &::=& \key{\#t} \mid \key{\#f} \\
   \itm{cmp} &::= & \key{eq?} \mid \key{<} \mid \key{<=} \mid \key{>} \mid \key{>=} \\
   \Exp &::=& \gray{ \Int \mid (\key{read}) \mid (\key{-}\;\Exp) \mid (\key{+} \; \Exp\;\Exp) }  \mid (\key{-}\;\Exp\;\Exp) \\
      &\mid&  \gray{ \Var \mid (\key{let}~([\Var~\Exp])~\Exp) } \\
@@ -4092,21 +4092,21 @@ the first argument:
 \begin{figure}[tp]
 \fbox{
 \begin{minipage}{0.96\textwidth}
-\small    
+\small
 \[
 \begin{array}{lcl}
-\Arg &::=&  \gray{\IMM{\Int} \mid \REG{\code{'}\Reg} \mid \DEREF{\Reg}{\Int}} 
+\Arg &::=&  \gray{\IMM{\Int} \mid \REG{\code{'}\Reg} \mid \DEREF{\Reg}{\Int}}
      \mid \BYTEREG{\code{'}\Reg} \\
 \itm{cc} & ::= & \key{e} \mid \key{l} \mid \key{le} \mid \key{g} \mid \key{ge} \\
-\Instr &::=& \gray{ \BININSTR{\code{'addq}}{\Arg}{\Arg} 
+\Instr &::=& \gray{ \BININSTR{\code{'addq}}{\Arg}{\Arg}
        \mid \BININSTR{\code{'subq}}{\Arg}{\Arg} } \\
-       &\mid& \gray{ \BININSTR{\code{'movq}}{\Arg}{\Arg} 
+       &\mid& \gray{ \BININSTR{\code{'movq}}{\Arg}{\Arg}
        \mid \UNIINSTR{\code{'negq}}{\Arg} } \\
-       &\mid& \gray{ \CALLQ{\itm{label}} \mid \RETQ{} 
+       &\mid& \gray{ \CALLQ{\itm{label}} \mid \RETQ{}
        \mid \PUSHQ{\Arg} \mid \POPQ{\Arg} \mid \JMP{\itm{label}} } \\
        &\mid& \BININSTR{\code{'xorq}}{\Arg}{\Arg}
        \mid \BININSTR{\code{'cmpq}}{\Arg}{\Arg}\\
-       &\mid& \BININSTR{\code{'set}}{\code{'}\itm{cc}}{\Arg} 
+       &\mid& \BININSTR{\code{'set}}{\code{'}\itm{cc}}{\Arg}
        \mid \BININSTR{\code{'movzbq}}{\Arg}{\Arg}\\
        &\mid&  \JMPIF{\code{'}\itm{cc}}{\itm{label}} \\
 \Block &::= & \gray{\BLOCK{\itm{info}}{\Instr^{+}}} \\
@@ -4176,7 +4176,7 @@ and \key{goto}'s.
 \begin{figure}[tbp]
 \fbox{
 \begin{minipage}{0.96\textwidth}
-\small    
+\small
 \[
 \begin{array}{lcl}
 \Atm &::=& \gray{ \Int \mid \Var } \mid \itm{bool} \\
@@ -4184,7 +4184,7 @@ and \key{goto}'s.
 \Exp &::=& \gray{ \Atm \mid \key{(read)} \mid \key{(-}~\Atm\key{)} \mid \key{(+}~\Atm~\Atm\key{)} } \\
    &\mid& \LP \key{not}~\Atm \RP \mid \LP \itm{cmp}~\Atm~\Atm\RP \\
 \Stmt &::=& \gray{ \Var~\key{=}~\Exp\key{;} } \\
-\Tail &::= & \gray{ \key{return}~\Exp\key{;} \mid \Stmt~\Tail } 
+\Tail &::= & \gray{ \key{return}~\Exp\key{;} \mid \Stmt~\Tail }
    \mid \key{goto}~\itm{label}\key{;}\\
    &\mid& \key{if}~\LP \itm{cmp}~\Atm~\Atm \RP~ \key{goto}~\itm{label}\key{;} ~\key{else}~\key{goto}~\itm{label}\key{;} \\
 C_1 & ::= & \gray{ (\itm{label}\key{:}~ \Tail)^{+} }
@@ -4199,17 +4199,17 @@ C_1 & ::= & \gray{ (\itm{label}\key{:}~ \Tail)^{+} }
 \begin{figure}[tp]
 \fbox{
 \begin{minipage}{0.96\textwidth}
-\small    
+\small
 \[
 \begin{array}{lcl}
 \Atm &::=& \gray{\INT{\Int} \mid \VAR{\Var}} \mid \BOOL{\itm{bool}} \\
 \itm{cmp} &::= & \key{eq?} \mid \key{<}  \\
 \Exp &::= & \gray{ \Atm \mid \READ{} }\\
      &\mid& \gray{ \NEG{\Atm} \mid \ADD{\Atm}{\Atm} } \\
-     &\mid& \UNIOP{\key{'not}}{\Atm} 
+     &\mid& \UNIOP{\key{'not}}{\Atm}
      \mid \BINOP{\key{'}\itm{cmp}}{\Atm}{\Atm} \\
 \Stmt &::=& \gray{ \ASSIGN{\VAR{\Var}}{\Exp} } \\
-\Tail &::= & \gray{\RETURN{\Exp} \mid \SEQ{\Stmt}{\Tail} } 
+\Tail &::= & \gray{\RETURN{\Exp} \mid \SEQ{\Stmt}{\Tail} }
     \mid \GOTO{\itm{label}} \\
     &\mid& \IFSTMT{\BINOP{\itm{cmp}}{\Atm}{\Atm}}{\GOTO{\itm{label}}}{\GOTO{\itm{label}}} \\
 C_1 & ::= & \gray{\PROGRAM{\itm{info}}{\CFG{\key{(}\itm{label}\,\key{.}\,\Tail\key{)}^{+}}}}
@@ -4277,7 +4277,7 @@ following code.
 \begin{lstlisting}
 (let ([x (read)])
   (let ([y (read)])
-    (if (< x 1) 
+    (if (< x 1)
       (if (eq? x 0)
         (+ y 2)
         (+ y 10))
@@ -4384,7 +4384,7 @@ block91:
     return (+ y 10);
 \end{lstlisting}
 \end{minipage}
-\end{tabular} 
+\end{tabular}
 
 \caption{Example translation from $R_2$ to $C_1$
   via the \code{explicate-control}.}
@@ -5089,13 +5089,13 @@ $42$.
   \itm{cmp} &::= & \gray{ \key{eq?} \mid \key{<} \mid \key{<=} \mid \key{>} \mid \key{>=} } \\
   \Exp &::=& \gray{  \Int \mid (\key{read}) \mid (\key{-}\;\Exp) \mid (\key{+} \; \Exp\;\Exp) \mid (\key{-}\;\Exp\;\Exp) }  \\
   &\mid&  \gray{  \Var \mid (\key{let}~([\Var~\Exp])~\Exp)  }\\
-  &\mid& \gray{ \key{\#t} \mid \key{\#f} 
-   \mid (\key{and}\;\Exp\;\Exp) 
+  &\mid& \gray{ \key{\#t} \mid \key{\#f}
+   \mid (\key{and}\;\Exp\;\Exp)
    \mid (\key{or}\;\Exp\;\Exp)
    \mid (\key{not}\;\Exp) } \\
-  &\mid& \gray{  (\itm{cmp}\;\Exp\;\Exp) 
+  &\mid& \gray{  (\itm{cmp}\;\Exp\;\Exp)
    \mid (\key{if}~\Exp~\Exp~\Exp)  } \\
-  &\mid& (\key{vector}\;\Exp^{+}) 
+  &\mid& (\key{vector}\;\Exp^{+})
    \mid (\key{vector-ref}\;\Exp\;\Int) \\
   &\mid& (\key{vector-set!}\;\Exp\;\Int\;\Exp)\\
   &\mid& (\key{void}) \\
@@ -5118,10 +5118,10 @@ $42$.
   \itm{bool} &::=& \key{\#t} \mid \key{\#f} \\
   \itm{cmp} &::= & \key{eq?} \mid \key{<} \mid \key{<=} \mid \key{>} \mid \key{>=} \\
 \Exp &::=& \gray{ \INT{\Int} \mid \READ{} \mid \NEG{\Exp} } \\
-     &\mid& \gray{ \ADD{\Exp}{\Exp} 
+     &\mid& \gray{ \ADD{\Exp}{\Exp}
       \mid \BINOP{\code{'-}}{\Exp}{\Exp} } \\
      &\mid& \gray{ \VAR{\Var} \mid \LET{\Var}{\Exp}{\Exp} } \\
-     &\mid& \gray{ \BOOL{\itm{bool}} 
+     &\mid& \gray{ \BOOL{\itm{bool}}
       \mid \AND{\Exp}{\Exp} }\\
      &\mid& \gray{ \OR{\Exp}{\Exp}
       \mid \NOT{\Exp} } \\
@@ -5694,7 +5694,7 @@ Figure~\ref{fig:expose-alloc-output} shows the output of the
    \mid \BINOP{\key{'vector-ref}}{\Atm}{\Int}  \\
    &\mid& (\key{Prim}~\key{'vector-set!}\,(\key{list}\,\Atm\,\Int\,\Atm))\\
    &\mid& (\key{GlobalValue} \,\itm{name}) \mid (\key{Void}) \\
-\Stmt &::=& \gray{ \ASSIGN{\VAR{\Var}}{\Exp} \mid \RETURN{\Exp} } 
+\Stmt &::=& \gray{ \ASSIGN{\VAR{\Var}}{\Exp} \mid \RETURN{\Exp} }
        \mid (\key{Collect} \,\itm{int}) \\
 \Tail &::= & \gray{ \RETURN{\Exp} \mid \SEQ{\Stmt}{\Tail} }\\
       &\mid& \gray{ \GOTO{\itm{label}} }\\
@@ -5743,7 +5743,7 @@ locals:
     collectret7978 : 'Void, tmp7985 : '(Vector Integer),
     tmp7984 : 'Integer, tmp7979 : 'Integer, tmp7982 : 'Integer,
     alloc7971 : '(Vector Integer), tmp7981 : 'Integer, vecinit7972 : 'Integer,
-    initret7973 : 'Void, 
+    initret7973 : 'Void,
 block7991:
     (collect 16);
     goto block7989;
@@ -5937,8 +5937,8 @@ Figure~\ref{fig:select-instr-output-gc} shows the output of the
                (movq (int 16) (reg rsi))
                (callq collect)
                (jmp block58))
-  (block59 . (block () 
-               (movq (int 0) (var collectret50)) 
+  (block59 . (block ()
+               (movq (int 0) (var collectret50))
                (jmp block58)))
   (block58 . (block ()
                (movq (global-value free_ptr) (var alloc47))
@@ -6227,7 +6227,7 @@ inside each other.
 \itm{cmp} &::= & \gray{  \key{eq?} \mid \key{<} \mid \key{<=} \mid \key{>} \mid \key{>=}  } \\
   \Exp &::=& \gray{ \Int \mid (\key{read}) \mid (\key{-}\;\Exp) \mid (\key{+} \; \Exp\;\Exp) \mid (\key{-}\;\Exp\;\Exp)}  \\
     &\mid&  \gray{ \Var \mid \LET{\Var}{\Exp}{\Exp} }\\
-    &\mid& \gray{ \key{\#t} \mid \key{\#f} 
+    &\mid& \gray{ \key{\#t} \mid \key{\#f}
     \mid (\key{and}\;\Exp\;\Exp)
     \mid (\key{or}\;\Exp\;\Exp)
     \mid (\key{not}\;\Exp)} \\
@@ -6385,7 +6385,7 @@ space called a frame. The caller sets the stack pointer, register
 \code{rsp}, to the last data item in its frame. The callee must not
 change anything in the caller's frame, that is, anything that is at or
 above the stack pointer. The callee is free to use locations that are
-below the stack pointer. 
+below the stack pointer.
 
 Regarding (3) the sharing of registers between different functions,
 recall from Section~\ref{sec:calling-conventions} that the registers
@@ -6405,7 +6405,7 @@ from the base pointer.
 Figure~\ref{fig:call-frames} shows the layout of the caller and callee
 frames.
 %% If we were to use stack arguments, they would be between the
-%% caller locals and the callee return address. 
+%% caller locals and the callee return address.
 
 
 
@@ -6605,7 +6605,7 @@ Figure~\ref{fig:f1-syntax}.
 %% Distinguishing between calls in tail position and non-tail position
 %% requires the pass to have some notion of context. We recommend using
 %% two mutually recursive functions, one for processing expressions in
-%% tail position and another for the rest. 
+%% tail position and another for the rest.
 
 Placing this pass after \code{uniquify} is a good idea, because it
 will make sure that there are no local variables and functions that
@@ -6625,7 +6625,7 @@ into a vector, making that subsequent vector the $n$th argument.
 \begin{tabular}{lll}
 \begin{minipage}{0.2\textwidth}
 \begin{lstlisting}
-  (|$f$| |$x_1$| |$\ldots$| |$x_n$|) 
+  (|$f$| |$x_1$| |$\ldots$| |$x_n$|)
 \end{lstlisting}
 \end{minipage}
 &
@@ -6686,7 +6686,7 @@ the function definitions.
    \mid (\key{vector-ref}\, \Arg\, \Int)  } \\
    &\mid& \gray{  (\key{vector-set!}\,\Arg\,\Int\,\Arg) \mid (\key{global-value} \,\itm{name}) \mid (\key{void}) } \\
    &\mid& (\key{fun-ref}\,\itm{label}) \mid (\key{call} \,\Arg\,\Arg^{*}) \\
-\Stmt &::=& \gray{ \ASSIGN{\Var}{\Exp} \mid \RETURN{\Exp} 
+\Stmt &::=& \gray{ \ASSIGN{\Var}{\Exp} \mid \RETURN{\Exp}
        \mid (\key{collect} \,\itm{int}) }\\
 \Tail &::= & \gray{\RETURN{\Exp} \mid (\key{seq}\;\Stmt\;\Tail)} \\
       &\mid& \gray{(\key{goto}\,\itm{label})
@@ -6724,7 +6724,7 @@ language, whose syntax is defined in Figure~\ref{fig:x86-3}.
 \begin{array}{lcl}
 \Arg &::=&  \gray{  \INT{\Int} \mid \REG{\Reg}
     \mid (\key{deref}\,\Reg\,\Int) } \\
-   &\mid& \gray{ (\key{byte-reg}\; \Reg) 
+   &\mid& \gray{ (\key{byte-reg}\; \Reg)
     \mid   (\key{global-value}\; \itm{name})  } \\
    &\mid& (\key{fun-ref}\; \itm{label})\\
 \itm{cc} & ::= & \gray{  \key{e} \mid \key{l} \mid \key{le} \mid \key{g} \mid \key{ge}  } \\
@@ -6827,7 +6827,7 @@ function definition.)
 
 %% The rest of the passes need only minor modifications to handle the new
 %% kinds of AST nodes: \code{fun-ref}, \code{indirect-callq}, and
-%% \code{leaq}. 
+%% \code{leaq}.
 
 Inside \code{uncover-live}, when computing the $W$ set (written
 variables) for an \code{indirect-callq} instruction, we recommend
@@ -6908,7 +6908,7 @@ $\Downarrow$
            [y88 : Integer]) : Integer ()
    ((add86start . (return (+ x87 y88)))))
  (define (main) : Integer ()
-   ((mainstart . 
+   ((mainstart .
       (seq (assign tmp89 (fun-ref add86))
            (tailcall tmp89 40 2))))))
 \end{lstlisting}
@@ -6919,7 +6919,7 @@ $\Rightarrow$
 \begin{lstlisting}[basicstyle=\ttfamily\scriptsize]
 (program ()
  (define (add86)
-   ((locals (x87 . Integer) (y88 . Integer)) 
+   ((locals (x87 . Integer) (y88 . Integer))
     (num-params . 2))
    ((add86start .
       (block ()
@@ -7073,7 +7073,7 @@ of your previously created test programs.
      {\ttfamily\footnotesize\color{red} select-instr.} (x86-2);
 \path[->,bend left=15] (x86-2) edge [left] node
      {\ttfamily\footnotesize\color{red} uncover-live} (x86-2-1);
-\path[->,bend right=15] (x86-2-1) edge [below] node 
+\path[->,bend right=15] (x86-2-1) edge [below] node
      {\ttfamily\footnotesize \color{red}build-inter.} (x86-2-2);
 \path[->,bend right=15] (x86-2-2) edge [left] node
      {\ttfamily\footnotesize allocate-reg.} (x86-3);
@@ -7153,9 +7153,9 @@ $R_3$).
   \Exp &::=& \gray{\Int \mid (\key{read}) \mid (\key{-}\;\Exp)
      \mid (\key{+} \; \Exp\;\Exp) \mid (\key{-} \; \Exp\;\Exp)}  \\
     &\mid&  \gray{\Var \mid \LET{\Var}{\Exp}{\Exp}}\\
-    &\mid& \gray{\key{\#t} \mid \key{\#f} 
-     \mid (\key{and}\;\Exp\;\Exp) 
-     \mid (\key{or}\;\Exp\;\Exp) 
+    &\mid& \gray{\key{\#t} \mid \key{\#f}
+     \mid (\key{and}\;\Exp\;\Exp)
+     \mid (\key{or}\;\Exp\;\Exp)
      \mid (\key{not}\;\Exp) } \\
     &\mid& \gray{(\key{eq?}\;\Exp\;\Exp) \mid \IF{\Exp}{\Exp}{\Exp}} \\
     &\mid& \gray{(\key{vector}\;\Exp^{+}) \mid
@@ -7169,7 +7169,7 @@ $R_3$).
 \]
 \end{minipage}
 }
-\caption{Syntax of $R_5$, extending $R_4$ (Figure~\ref{fig:r4-syntax}) 
+\caption{Syntax of $R_5$, extending $R_4$ (Figure~\ref{fig:r4-syntax})
   with \key{lambda}.}
 \label{fig:r5-syntax}
 \end{figure}
@@ -7293,7 +7293,7 @@ require the body's type to match the declared return type.
 The compiling of lexically-scoped functions into top-level function
 definitions is accomplished in the pass \code{convert-to-closures}
 that comes after \code{reveal-functions} and before
-\code{limit-functions}. 
+\code{limit-functions}.
 
 As usual, we shall implement the pass as a recursive function over the
 AST. All of the action is in the clauses for \key{lambda} and
@@ -7483,7 +7483,7 @@ $\Downarrow$
      {\ttfamily\footnotesize select-instr.} (x86-2);
 \path[->,bend left=15] (x86-2) edge [left] node
      {\ttfamily\footnotesize uncover-live} (x86-2-1);
-\path[->,bend right=15] (x86-2-1) edge [below] node 
+\path[->,bend right=15] (x86-2-1) edge [below] node
      {\ttfamily\footnotesize build-inter.} (x86-2-2);
 \path[->,bend right=15] (x86-2-2) edge [left] node
      {\ttfamily\footnotesize allocate-reg.} (x86-3);
@@ -7549,12 +7549,12 @@ reference results in a run-time contract violation.
 \[
 \begin{array}{rcl}
   \itm{cmp} &::= & \key{eq?} \mid \key{<} \mid \key{<=} \mid \key{>} \mid \key{>=} \\
-\Exp &::=& \Int \mid (\key{read}) \mid (\key{-}\;\Exp) 
+\Exp &::=& \Int \mid (\key{read}) \mid (\key{-}\;\Exp)
       \mid (\key{+} \; \Exp\;\Exp) \mid (\key{-} \; \Exp\;\Exp)  \\
      &\mid&  \Var \mid \LET{\Var}{\Exp}{\Exp} \\
-     &\mid& \key{\#t} \mid \key{\#f} 
-      \mid (\key{and}\;\Exp\;\Exp) 
-      \mid (\key{or}\;\Exp\;\Exp) 
+     &\mid& \key{\#t} \mid \key{\#f}
+      \mid (\key{and}\;\Exp\;\Exp)
+      \mid (\key{or}\;\Exp\;\Exp)
       \mid (\key{not}\;\Exp) \\
      &\mid& (\itm{cmp}\;\Exp\;\Exp) \mid \IF{\Exp}{\Exp}{\Exp} \\
      &\mid& (\key{vector}\;\Exp^{+}) \mid
@@ -7722,9 +7722,9 @@ extend our compiler to handle the new features of $R_6$
   \Exp &::=& \gray{\Int \mid (\key{read}) \mid (\key{-}\;\Exp)
      \mid (\key{+} \; \Exp\;\Exp) \mid (\key{-} \; \Exp\;\Exp)}  \\
     &\mid&  \gray{\Var \mid \LET{\Var}{\Exp}{\Exp}} \\
-    &\mid& \gray{\key{\#t} \mid \key{\#f} 
-     \mid (\key{and}\;\Exp\;\Exp) 
-     \mid (\key{or}\;\Exp\;\Exp) 
+    &\mid& \gray{\key{\#t} \mid \key{\#f}
+     \mid (\key{and}\;\Exp\;\Exp)
+     \mid (\key{or}\;\Exp\;\Exp)
      \mid (\key{not}\;\Exp)} \\
     &\mid& \gray{(\itm{cmp}\;\Exp\;\Exp) \mid \IF{\Exp}{\Exp}{\Exp}} \\
     &\mid& \gray{(\key{vector}\;\Exp^{+}) \mid
@@ -7939,7 +7939,7 @@ $\Rightarrow$
 (orq (int |$\itm{tagof}(T)$|) |\itm{lhs}'|)
 \end{lstlisting}
 \end{minipage}
-\end{tabular} 
+\end{tabular}
 
 \paragraph{Tag of Any}
 
@@ -7963,7 +7963,7 @@ $\Rightarrow$
 (andq (int 7) |\itm{lhs}'|)
 \end{lstlisting}
 \end{minipage}
-\end{tabular}  
+\end{tabular}
 
 \paragraph{Value of Any}
 
@@ -8013,7 +8013,7 @@ $\Rightarrow$
 (andq |$e'$| |\itm{lhs}'|)
 \end{lstlisting}
 \end{minipage}
-\end{tabular}  
+\end{tabular}
 
 %% \paragraph{Type Predicates} We leave it to the reader to
 %% devise a sequence of instructions to implement the type predicates
@@ -8182,7 +8182,7 @@ $\Rightarrow$
 \end{lstlisting}
 \end{minipage}
 \\[2ex]\hline
-\end{tabular} 
+\end{tabular}
 
 \caption{Compiling $R_7$ to $R_6$.}
 \label{fig:compile-r7-r6}


### PR DESCRIPTION
This PR corrects a typo in the error call for interp-R0.

Related PRs
* https://github.com/IUCompilerCourse/IU-P423-P523-E313-E513-Fall-2020/pull/3