### PR TITLE
Fix example code for calling interp-R0 on ast1.1

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -919,7 +919,7 @@ operation prompts the user of the program for an integer.  Recall that
 program \eqref{eq:arith-prog} performs a \key{read} and then subtracts
 \code{8}. So if we run
 \begin{lstlisting}
-(interp-R0 ast1.1)
+(interp-R0 (Program '() ast1.1))
 \end{lstlisting}
 and if the input is \code{50}, then we get the answer to life, the
 universe, and everything: \code{42}!\footnote{\emph{The Hitchhiker's


### PR DESCRIPTION
Fix call to interp-R0 with ast1.1 to make example code runnable.