### PR TITLE
Match on empty list instead of pattern variable in partial evaluator for R0

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1003,7 +1003,7 @@ functions is the output of partially evaluating the children.
 
 (define (pe-R0 p)
   (match p
-    [(Program info e) (Program info (pe-exp e))]
+    [(Program '() e) (Program '() (pe-exp e))]
     ))
 \end{lstlisting}
 \caption{A partial evaluator for $R_0$ expressions.}


### PR DESCRIPTION
This PR corrects the pattern case/cause for the R0 partial evaluator to accurately reflect the R0 grammar.