### PR TITLE
Match on empty list instead of pattern variable in interp-R1 and uniquify

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1908,8 +1908,8 @@ implement the clauses for variables and for the \key{let} form.
 
    (define (uniquify p)
      (match p
-       [(Program info e)
-        (Program info ((uniquify-exp '()) e))]
+       [(Program '() e)
+        (Program '() ((uniquify-exp '()) e))]
        )))
 \end{lstlisting}
 \caption{Skeleton for the \key{uniquify} pass.}

--- a/book.tex
+++ b/book.tex
@@ -1227,7 +1227,7 @@ environment with the result value bound to the variable, using
 
 (define (interp-R1 p)
   (match p
-    [(Program info e) ((interp-exp '()) e)]
+    [(Program '() e) ((interp-exp '()) e)]
     ))
 \end{lstlisting}
 \caption{Interpreter for the $R_1$ language.}


### PR DESCRIPTION
This PR corrects the pattern case/clause for the R1 interpreter to accurately reflect the R1 grammar.