### PR TITLE
Fixed "sleight of hand" typo in Ch5

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -6136,7 +6136,7 @@ So the goal of the garbage collector is twofold:
   \emph{garbage}.
 \end{enumerate}
 A copying collector accomplishes this by copying all of the live
-objects from the FromSpace into the ToSpace and then performs a slight
+objects from the FromSpace into the ToSpace and then performs a sleight
 of hand, treating the ToSpace as the new FromSpace and the old
 FromSpace as the new ToSpace.  In the example of
 Figure~\ref{fig:copying-collector}, there are three pointers in the


### PR DESCRIPTION
While working through the book I spotted a typo. 

The correct spelling is "sleight of hand." Slight means thin, while sleight means using skill or dexterity. 

https://www.merriam-webster.com/words-at-play/sleight-vs-slight-usage-legerdemain