### PR TITLE
CALLQ, INDCALLQ and TAILJMP should have only 1 argument.

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1741,7 +1741,7 @@ of arguments, which is helpful to know during register allocation
        \mid \BININSTR{\code{subq}}{\Arg}{\Arg} \\
        &\mid& \BININSTR{\code{movq}}{\Arg}{\Arg}
        \mid \UNIINSTR{\code{negq}}{\Arg}\\
-       &\mid& \CALLQ{\itm{label}}{\itm{int}} \mid \RETQ{} 
+       &\mid& \CALLQ{\itm{label}} \mid \RETQ{}
        \mid \PUSHQ{\Arg} \mid \POPQ{\Arg} \mid \JMP{\itm{label}} \\
 \Block &::= & \BLOCK{\itm{info}}{\LP\Instr\ldots\RP} \\
 \LangXInt{} &::= & \XPROGRAM{\itm{info}}{\LP\LP\itm{label} \,\key{.}\, \Block \RP\ldots\RP}
@@ -5010,7 +5010,7 @@ the first argument:
        \mid \BININSTR{\code{subq}}{\Arg}{\Arg} } \\
        &\mid& \gray{ \BININSTR{\code{'movq}}{\Arg}{\Arg} 
        \mid \UNIINSTR{\code{negq}}{\Arg} } \\
-       &\mid& \gray{ \CALLQ{\itm{label}}{\itm{int}} \mid \RETQ{} 
+       &\mid& \gray{ \CALLQ{\itm{label}} \mid \RETQ{}
        \mid \PUSHQ{\Arg} \mid \POPQ{\Arg} \mid \JMP{\itm{label}} } \\
        &\mid& \BININSTR{\code{xorq}}{\Arg}{\Arg}
        \mid \BININSTR{\code{cmpq}}{\Arg}{\Arg}\\
@@ -8275,8 +8275,8 @@ language, whose syntax is defined in Figure~\ref{fig:x86-3}.
   \Arg &::=&  \gray{  \INT{\Int} \mid \REG{\Reg} \mid \DEREF{\Reg}{\Int}
      \mid \BYTEREG{\Reg} } \\
      &\mid& \gray{ (\key{Global}~\Var) } \mid \FUNREF{\itm{label}} \\
-  \Instr &::=& \ldots \mid \INDCALLQ{\Arg}{\itm{int}}
-    \mid \TAILJMP{\Arg}{\itm{int}}\\
+  \Instr &::=& \ldots \mid \INDCALLQ{\Arg}
+    \mid \TAILJMP{\Arg}\\
     &\mid& \BININSTR{\code{'leaq}}{\Arg}{\REG{\Reg}}\\
   \Block &::= & \BLOCK{\itm{info}}{\LP\Instr\ldots\RP}\\
   \Def &::= & \DEF{\itm{label}}{\code{'()}}{\Type}{\itm{info}}{\LP\LP\itm{label}\,\key{.}\,\Block\RP\ldots\RP} \\

--- a/defs.tex
+++ b/defs.tex
@@ -163,13 +163,13 @@
 \newcommand{\STACKLOC}[1]{(\key{stack}\;#1)}
 \newcommand{\BININSTR}[3]{\key{(Instr}\;#1\;\key{(}\;#2\;#3\key{))}}
 \newcommand{\UNIINSTR}[2]{\key{(Instr}\;#1\;\key{(}\;#2\key{))}}
-\newcommand{\CALLQ}[2]{\key{(Callq}~#1~#2\key{)}}
-\newcommand{\INDCALLQ}[2]{\key{(IndirectCallq}~#1~#2\key{)}}
+\newcommand{\CALLQ}[1]{\key{(Callq}~#1\key{)}}
+\newcommand{\INDCALLQ}[1]{\key{(IndirectCallq}~#1\key{)}}
 \newcommand{\RETQ}{\key{(Retq)}}
 \newcommand{\PUSHQ}[1]{\key{(Pushq}~#1\key{)}}
 \newcommand{\POPQ}[1]{\key{(Popq}~#1\key{)}}
 \newcommand{\JMP}[1]{\key{(Jmp}~#1\key{)}}
-\newcommand{\TAILJMP}[2]{\key{(TailJmp}~#1~#2\key{)}}
+\newcommand{\TAILJMP}[1]{\key{(TailJmp}~#1\key{)}}
 \newcommand{\JMPIF}[2]{\key{(JmpIf}~#1~#2\key{)}}
 
 


### PR DESCRIPTION
Definition in `utilities.rkt`:

```
(struct Callq (target)
  #:methods gen:custom-write
  [(define (write-proc ast port mode)
     (match ast
       [(Callq target)
        (let-values ([(line col pos) (port-next-location port)])
          (write-string "callq" port)
          (write-string " " port)
          (write target port)
          (newline-and-indent port col))
        ]))])

(struct IndirectCallq (target)
  #:methods gen:custom-write
  [(define (write-proc ast port mode)
     (let ([recur (make-recur port mode)])
       (match ast
         [(IndirectCallq target)
          (let-values ([(line col pos) (port-next-location port)])
            (write-string "callq" port)
            (write-string " " port)
            (write-string "*" port)
            (recur target port)
            (newline-and-indent port col))])))])

(struct TailJmp (target)
  #:methods gen:custom-write
  [(define (write-proc ast port mode)
     (match ast
       [(TailJmp target)
        (let-values ([(line col pos) (port-next-location port)])
          (write-string "tailjmp" port)
          (write-string " " port)
          (write target port)
          (newline-and-indent port col))
        ]))])

```