### PR TITLE
Fix labels in 4.12.2 Remove jumps

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -9403,9 +9403,9 @@ block_1:
 
 There is an opportunity for removing jumps that is apparent in the
 example of Figure~\ref{fig:if-example-x86}. The \code{start} block
-ends with a jump to \code{block\_4} and there are no other jumps to
-\code{block\_4} in the rest of the program. In this situation we can
-avoid the runtime overhead of this jump by merging \code{block\_4}
+ends with a jump to \code{block7953} and there are no other jumps to
+\code{block7953} in the rest of the program. In this situation we can
+avoid the runtime overhead of this jump by merging \code{block7953}
 into the preceding block, in this case the \code{start} block.
 Figure~\ref{fig:remove-jumps} shows the output of
 \code{select\_instructions} on the left and the result of this


### PR DESCRIPTION
This paragraph refers to the figures 4.14 and 4.17, which do not have `block_4` label. Perhaps the cleaner solution would be to regenerate the code with new, smaller label indices and change `block_4` accordingly.