### PR TITLE
Remove Def from abstract syntax of Cloop (racket)

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -10410,8 +10410,7 @@ Figure~\ref{fig:Rwhile-anf-syntax} defines the output language
       \MID \SETBANG{\Var}{\Exp} \\
      &\MID& \BEGIN{\LP\Exp\ldots\RP}{\Exp}
       \MID \WHILE{\Exp}{\Exp} \\
-\Def &::=& \gray{ \FUNDEF{\Var}{([\Var \code{:} \Type]\ldots)}{\Type}{\code{'()}}{\Exp} }\\
-\LangLoopANF  &::=& \gray{ \PROGRAMDEFS{\code{'()}}{\Def} }
+\LangLoopANF  &::=& \gray{ \PROGRAM{\code{'()}}{\Exp} }
 \end{array}
 \]
 \fi}

--- a/book.tex
+++ b/book.tex
@@ -10483,8 +10483,7 @@ fine to place \code{begin} there.
 \newcommand{\CloopASTRacket}{
 \begin{array}{lcl}
 \Atm  &::=&  \VOID \\
-\Stmt &::=& \READ{}\\
-\Def &::=& \DEF{\itm{label}}{\LP\LS\Var\key{:}\Type\RS\ldots\RP}{\Type}{\itm{info}}{\LP\LP\itm{label}\,\key{.}\,\Tail\RP\ldots\RP}
+\Stmt &::=& \READ{}
 \end{array}
 }
 


### PR DESCRIPTION
If I understand it right, on Figure 5.7 (Racket version) there is a leftover from previous major edition - line

`def :== (Def label ([var:type] ....)`

Similar leftover is on Figure 5.6 (Racket version).

Would you please check if I am right and these corrections are correct. Please feel free to close this PR if you want to fix it in a better way.