### PR TITLE
Fix month in Appel90 bibtex record.

### DIFF
--- a/book.bib
+++ b/book.bib
@@ -36,7 +36,7 @@
   volume = 	 3,
   number = 	 4,
   pages = 	 {343--380},
-  month = 	 {November}}
+  month = 	 nov}
 
 @book{Appel91,
   place={Cambridge},


### PR DESCRIPTION
bibtex pointed out that "November is not a number". It should be replaced with `nov`, like in other records.