### PR TITLE
Fixed create_block with promises

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -9396,7 +9396,7 @@ return a \code{Goto} to the new label.
       [(Goto label) (Goto label)]
       [else
         (let ([label (gensym 'block)])
-          (set! basic-blocks (cons (cons label tail) basic-blocks))
+          (set! basic-blocks (cons (cons label t) basic-blocks))
           (Goto label))]))
 \end{lstlisting}
 \end{minipage}


### PR DESCRIPTION
We should set the tail and not the promise as the value of the label in the basic blocks dictionary.