### PR TITLE
Fix typo: output of assign-homes is X86_Int (not X86_Var)

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -3014,7 +3014,7 @@ that uses a reserved register to fix outstanding problems.
 \node (Cvar-2) at (0,0)  {\large \LangCVar{}};
 
 \node (x86-2) at (0,-2)  {\large \LangXVar{}};
-\node (x86-3) at (3,-2)  {\large \LangXVar{}};
+\node (x86-3) at (3,-2)  {\large \LangXInt{}};
 \node (x86-4) at (7,-2) {\large \LangXInt{}};
 \node (x86-5) at (11,-2) {\large \LangXInt{}};
 
@@ -3033,7 +3033,7 @@ that uses a reserved register to fix outstanding problems.
 \node (Lvar) at (0,2)  {\large \LangVar{}};
 \node (Lvar-2) at (4,2)  {\large \LangVarANF{}};
 \node (x86-1) at (0,0)  {\large \LangXVar{}};
-\node (x86-2) at (4,0)  {\large \LangXVar{}};
+\node (x86-2) at (4,0)  {\large \LangXInt{}};
 \node (x86-3) at (8,0) {\large \LangXInt{}};
 \node (x86-4) at (12,0) {\large \LangXInt{}};
 
@@ -6843,7 +6843,7 @@ and \code{pushq} subtracts $8$ from the \code{rsp}.
 \node (Cvar-1) at (0,0)  {\large \LangCVar{}};
 
 \node (x86-2) at (0,-2)  {\large \LangXVar{}};
-\node (x86-3) at (3,-2)  {\large \LangXVar{}};
+\node (x86-3) at (3,-2)  {\large \LangXInt{}};
 \node (x86-4) at (7,-2) {\large \LangXInt{}};
 \node (x86-5) at (7,-4) {\large \LangXInt{}};
 
@@ -10267,7 +10267,7 @@ compilation of \LangIf{}.
 \node (x86-2) at (0,-2)  {\large \LangXIfVar{}};
 \node (x86-2-1) at (0,-4)  {\large \LangXIfVar{}};
 \node (x86-2-2) at (4,-4)  {\large \LangXIfVar{}};
-\node (x86-3) at (4,-2)  {\large \LangXIfVar{}};
+\node (x86-3) at (4,-2)  {\large \LangXIf{}};
 \node (x86-4) at (8,-2) {\large \LangXIf{}};
 \node (x86-5) at (8,-4) {\large \LangXIf{}};
 
@@ -10291,7 +10291,7 @@ compilation of \LangIf{}.
 \node (C-1) at (0,0)  {\large \LangCIf{}};
 
 \node (x86-1) at (0,-2)  {\large \LangXIfVar{}};
-\node (x86-2) at (4,-2)  {\large \LangXIfVar{}};
+\node (x86-2) at (4,-2)  {\large \LangXIf{}};
 \node (x86-3) at (8,-2)  {\large \LangXIf{}};
 \node (x86-4) at (12,-2) {\large \LangXIf{}};
 
@@ -11980,7 +11980,7 @@ The \code{analyze\_dataflow} function has the following four parameters.
 \node (x86-2) at (0,-2)  {\large \LangXIfVar{}};
 \node (x86-2-1) at (0,-4)  {\large \LangXIfVar{}};
 \node (x86-2-2) at (4,-4)  {\large \LangXIfVar{}};
-\node (x86-3) at (4,-2)  {\large \LangXIfVar{}};
+\node (x86-3) at (4,-2)  {\large \LangXIf{}};
 \node (x86-4) at (8,-2) {\large \LangXIf{}};
 \node (x86-5) at (8,-4) {\large \LangXIf{}};
 
@@ -12016,7 +12016,7 @@ The \code{analyze\_dataflow} function has the following four parameters.
 \node (C3-2) at (0,0)  {\large \racket{\LangCLoop{}}\python{\LangCIf{}}};
 
 \node (x86-2) at (0,-2)  {\large \LangXIfVar{}};
-\node (x86-3) at (4,-2)  {\large \LangXIfVar{}};
+\node (x86-3) at (4,-2)  {\large \LangXIf{}};
 \node (x86-4) at (8,-2) {\large \LangXIf{}};
 \node (x86-5) at (12,-2) {\large \LangXIf{}};
 
@@ -13905,7 +13905,7 @@ conclusion:
 \node (x86-2) at (0,-2)  {\large \LangXGlobalVar{}};
 \node (x86-2-1) at (0,-4)  {\large \LangXGlobalVar{}};
 \node (x86-2-2) at (4,-4)  {\large \LangXGlobalVar{}};
-\node (x86-3) at (4,-2)  {\large \LangXGlobalVar{}};
+\node (x86-3) at (4,-2)  {\large \LangXGlobal{}};
 \node (x86-4) at (8,-2) {\large \LangXGlobal{}};
 \node (x86-5) at (8,-4) {\large \LangXGlobal{}};
 
@@ -13933,7 +13933,7 @@ conclusion:
 \node (C2-4) at (0,0)  {\large \LangCVec{}};
 
 \node (x86-2) at (0,-2)  {\large \LangXGlobalVar{}};
-\node (x86-3) at (4,-2)  {\large \LangXGlobalVar{}};
+\node (x86-3) at (4,-2)  {\large \LangXGlobal{}};
 \node (x86-4) at (8,-2) {\large \LangXGlobal{}};
 \node (x86-5) at (12,-2) {\large \LangXGlobal{}};
 
@@ -16378,7 +16378,7 @@ previously created test programs.
 \node (C3-2) at (0,-2)  {\large \LangCFun{}};
 
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (8,-6) {\large \LangXIndCallFlat{}};
 
@@ -16425,7 +16425,7 @@ previously created test programs.
 \node (C3-2) at (0,-2)  {\large \LangCFun{}};
 
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (12,-4) {\large \LangXIndCallFlat{}};
 
@@ -18020,7 +18020,7 @@ needed for the compilation of \LangLam{}.
 \node (x86-2) at (0,-5)  {\large \LangXIndCallVar{}};
 \node (x86-2-1) at (0,-7)  {\large \LangXIndCallVar{}};
 \node (x86-2-2) at (4,-7)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-5)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-5)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-5) {\large \LangXIndCall{}};
 \node (x86-5) at (8,-7) {\large \LangXIndCall{}};
 
@@ -18072,7 +18072,7 @@ needed for the compilation of \LangLam{}.
 \node (C3-2) at (0,-4)  {\large \LangCFun{}};
 
 \node (x86-2) at (0,-6)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-6)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-6)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-6) {\large \LangXIndCall{}};
 \node (x86-5) at (12,-6) {\large \LangXIndCall{}};
 
@@ -20168,7 +20168,7 @@ for the compilation of \LangDyn{}.
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
 \node (x86-2-1) at (0,-6)  {\large \LangXIndCallVar{}};
 \node (x86-2-2) at (4,-6)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (8,-6) {\large \LangXIndCall{}};
 
@@ -20228,7 +20228,7 @@ for the compilation of \LangDyn{}.
 \node (C3-2) at (0,-2)  {\large \LangCAny{}};
 
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (12,-4) {\large \LangXIndCall{}};
 
@@ -22222,7 +22222,7 @@ and \code{proxy\_vector\_length} functions.
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
 \node (x86-2-1) at (0,-6)  {\large \LangXIndCallVar{}};
 \node (x86-2-2) at (4,-6)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (8,-6) {\large \LangXIndCall{}};
 
@@ -22289,7 +22289,7 @@ and \code{proxy\_vector\_length} functions.
 \node (C3-2) at (0,-2)  {\large \LangCLoopPVec{}};
 
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (12,-4) {\large \LangXIndCall{}};
 
@@ -23423,7 +23423,7 @@ annotations and the body.
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
 \node (x86-2-1) at (0,-6)  {\large \LangXIndCallVar{}};
 \node (x86-2-2) at (4,-6)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (8,-6) {\large \LangXIndCall{}};
 
@@ -23489,7 +23489,7 @@ annotations and the body.
 \node (C3-2) at (0,-2)  {\large \LangCLoopPVec{}};
 
 \node (x86-2) at (0,-4)  {\large \LangXIndCallVar{}};
-\node (x86-3) at (4,-4)  {\large \LangXIndCallVar{}};
+\node (x86-3) at (4,-4)  {\large \LangXIndCall{}};
 \node (x86-4) at (8,-4) {\large \LangXIndCall{}};
 \node (x86-5) at (12,-4) {\large \LangXIndCall{}};
 


### PR DESCRIPTION
Figure 2.10 (Python version) lists the output of assign_homes as X86_Var (and all the other diagrams in both versions are similar). But I think the output language of this pass is actually X86_Int, right?