### PR TITLE
Fix parens around "super"

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -2139,7 +2139,7 @@ inherits from the class for \LangInt{}, and the method
          (define env^ (dict-set env x v))
          ((interp_exp env^) body)]
         [else
-         (super (interp_exp env) e)]))
+         ((super interp_exp env) e)]))
     ...
   ))
 \end{lstlisting}


### PR DESCRIPTION
`super` was not being invoked properly in the overridden method `interp_exp` of class `inter-Lvar-class`.