### PR TITLE
fix typo in InterpLvar python example

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -2163,7 +2163,7 @@ class InterpLint:
 \end{minipage}
 \begin{minipage}{0.45\textwidth}
   \begin{lstlisting}
-def InterpLvar(InterpLint):
+class InterpLvar(InterpLint):
   def interp_exp(e):
     match e:
       case Name(id):


### PR DESCRIPTION
`InterpLvar` should be a class, not a function (Python example, page 15, section 2.1.1).

fixes #170