### PR TITLE
Add missing close paren in Racket listing

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1328,7 +1328,7 @@ two examples at the bottom of the figure, the first is in
     [(Program '() e) (is_exp e)]
     [else #f]))
 
-(is_Lint (Program '() ast1_1)
+(is_Lint (Program '() ast1_1))
 (is_Lint (Program '()
        (Prim '* (list (Prim 'read '())
                       (Prim '+ (list (Int 8)))))))


### PR DESCRIPTION
## Issue

One of the Racket listings is missing a closing paren.

## Solution

This PR adds the missing paren.

## Verification

* Checked the book.pdf file generated by `make`
* Checked the following program
```racket
#lang racket

(struct Int (value))
(struct Prim (op args))
(struct Program (info body))
(define rd (Prim 'read '()))
(define neg-eight (Prim '- (list (Int 8))))
(define ast1_1 (Prim '+ (list rd neg-eight)))

(define (is_exp ast)
  (match ast
    [(Int n) #t]
    [(Prim 'read '()) #t]
    [(Prim '- (list e)) (is_exp e)]
    [(Prim '+ (list e1 e2))
     (and (is_exp e1) (is_exp e2))]
    [(Prim '- (list e1 e2))
     (and (is_exp e1) (is_exp e2))]
    [else #f]))

(define (is_Lint ast)
  (match ast
    [(Program '() e) (is_exp e)]
    [else #f]))

(is_Lint (Program '() ast1_1))
(is_Lint (Program '() (Prim '* (list (Prim 'read '())
                                     (Prim '+ (list (Int 8)))))))
```

It returns
```
#t
#f
```