### PR TITLE
Chapter 2: First argument to a function call should be placed in %rdi

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -3965,14 +3965,14 @@ example, we assign variable \code{a} to stack location
 \begin{lstlisting}[basicstyle=\ttfamily\footnotesize]
 movq $42, a
 movq a, b
-movq b, %rax
+movq b, %rdi
 \end{lstlisting}
 \compilesto
 %stack-space: 16
 \begin{lstlisting}[basicstyle=\ttfamily\footnotesize]
 movq $42, -8(%rbp)
 movq -8(%rbp), -16(%rbp)
-movq -16(%rbp), %rax
+movq -16(%rbp), %rdi
 \end{lstlisting}
 \end{transformation}
 
@@ -4059,7 +4059,7 @@ The \code{assign\_homes} pass produces the following translation. \\
 \begin{lstlisting}
     movq $42, -8(%rbp)
     movq -8(%rbp), -16(%rbp)
-    movq -16(%rbp), %rax
+    movq -16(%rbp), %rdi
 \end{lstlisting}
 \fi}
 {\if\edition\pythonEd\pythonColor


### PR DESCRIPTION
There was a typo in the example shown in the assign homes pass. The generated assembly should put the argument for print_int into %rdi instead of %rax, before the callq instruction.

The assembly shown for the Python version in the patch instructions pass looks correct, but the racket version still had the typo.