### PR TITLE
Fix FunRef->Closure conversion Racket

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -17919,7 +17919,7 @@ $\Rightarrow\qquad$
 \begin{minipage}{0.5\textwidth}
 {\if\edition\racketEd
 \begin{lstlisting}
-(Closure |$n$| (FunRef |$f$| |$n$|) '())
+(Closure |$n$| (cons (FunRef |$f$| |$n$|) '()))
 \end{lstlisting}
 \fi}
 {\if\edition\pythonEd\pythonColor


### PR DESCRIPTION
Under section 8.4 Closure Conversion the racket version of the book states the following

```(FunRef f n) => (Closure n (FunRef f n) '())```

When the correct statement should be

```(FunRef f n) => (Closure n (cons (FunRef f n) '()))```

As the Closure struct expects only two arguments.