### PR TITLE
Remove typo/additional space

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -2016,7 +2016,7 @@ study. Because each language builds on the prior one, there is a lot
 of commonality between these interpreters. We want to write down the
 common parts just once instead of many times. A naive interpreter for
 \LangVar{} would handle the \racket{cases for variables and
-  \code{let}} \python{case for variables} but dispatch to an
+  \code{let}}\python{case for variables} but dispatch to an
 interpreter for \LangInt{} in the rest of the cases. The following
 code sketches this idea. (We explain the \code{env} parameter in
 section~\ref{sec:interp-Lvar}.)


### PR DESCRIPTION
Fix unwanted additional space from TeX: `the  case for variables` -> `the case for variables`