### PR TITLE
Section 1: Fix typo in figure 1.5

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -1769,7 +1769,7 @@ def pe_stmt(s):
     case Expr(value):
       return Expr(pe_exp(value))
 
-def pe_P_int(p):
+def pe_Lint(p):
   match p:
     case Module(body):
       new_body = [pe_stmt(s) for s in body]


### PR DESCRIPTION
Python version of the book references `pe_Lint` in exercise 1.1 (page 10), while figure 1.5 references `pe_P_int`. This PR changes the function name to `pe_Lint` for consistency.