### PR TITLE
Python edition - Figure 9.3 - Language non-terminal should be  Lλ and not LFun

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -17411,7 +17411,7 @@ for \LangFun{}, which already has syntax for function application.
   \gray{\LfunGrammarPython} \\   \hline
   \LlambdaGrammarPython \\
   \begin{array}{lcl}
-    \LangFunM{} &::=& \Def\ldots \Stmt\ldots
+    \LangLamM{} &::=& \Def\ldots \Stmt\ldots
   \end{array}
 \end{array}
 \]


### PR DESCRIPTION
Fixed figure 9.3 in the python edition's Language non-terminal

Old with issue:
<img width="797" height="561" alt="image" src="https://github.com/user-attachments/assets/c46b0d99-7c59-4bd9-94bf-57f4223161ab" />
